### PR TITLE
MQTT Client Support

### DIFF
--- a/mqtt-client.py
+++ b/mqtt-client.py
@@ -1,0 +1,34 @@
+import paho.mqtt.client as mqtt
+import mqtt_config as config
+import os
+
+broker_url = config.broker_url
+broker_port = config.broker_port
+state = "OFF"
+
+def on_connect(client, userdata, flags, rc):
+   print("Connected With Result Code: {}".format(rc))
+
+def on_message(client, userdata, message):
+    decodedMessage = message.payload.decode()
+    print("Message received from broker: "+ decodedMessage)
+    if decodedMessage == 'ON':
+        os.system('sudo python3 metar.py')
+        state = "ON"
+    elif (decodedMessage == 'OFF') :
+        os.system('sudo ./lightsoff.sh')
+        state = "OFF"
+
+client = mqtt.Client('metarmap')
+client.on_connect = on_connect
+#To Process Every Other Message
+client.on_message = on_message
+
+if config.broker_username:
+    client.username_pw_set(username=config.broker_username, password=config.broker_password)
+client.connect(broker_url, broker_port)
+
+client.subscribe(config.set_topic, qos=1)
+client.publish(topic=config.state_topic, payload=state, qos=0, retain=False)
+
+client.loop_forever()

--- a/mqtt-client.py
+++ b/mqtt-client.py
@@ -2,8 +2,6 @@ import paho.mqtt.client as mqtt
 import mqtt_config as config
 import os
 
-broker_url = config.broker_url
-broker_port = config.broker_port
 state = "OFF"
 
 def on_connect(client, userdata, flags, rc):
@@ -26,7 +24,7 @@ client.on_message = on_message
 
 if config.broker_username:
     client.username_pw_set(username=config.broker_username, password=config.broker_password)
-client.connect(broker_url, broker_port)
+client.connect(config.broker_url, config.broker_port)
 
 client.subscribe(config.set_topic, qos=1)
 client.publish(topic=config.state_topic, payload=state, qos=0, retain=False)


### PR DESCRIPTION
The time-based approach of controlling the map is great, but I wanted to add a little more flexibility in how I turn on and off my map. I'm a [Home Assistant](https://github.com/home-assistant) user and wanted to integrate the map into my existing home automation, as well as expose it to my voice assistants. MQTT enables the map to report its state and be controlled by a MQTT broker.

The sole dependency is `paho-mqtt` which I installed with pip.

Configuration is managed through a private `mqtt_config.py` file that looks like
```
broker_url = <broker_url>
broker_port = <broker_port>
set_topic = "home/metarmap/set"
state_topic = "home/metarmap/state"
broker_username = "admin"
broker_password = "notrealpass"
```

To run the client permanently, I set up a service
`sudo vim /etc/systemd/system/mqtt-client.service`
```
[Unit]
Description=mqtt client service

[Service]
ExecStart=python3 mqtt-client.py
WorkingDirectory=/home/pi/
Restart=always
RestartSec=10
User=pi

[Install]
WantedBy=multi-user.target 
```
And then enabled it
```
sudo systemctl enable mqtt-client.service
sudo systemctl start mqtt-client.service
```
